### PR TITLE
Build conditional libtxc-dxtn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ before_script:
   - pip install docker-jinja
 
 script:
-  - docker build -f Dockerfile.base -t igalia/mesa:base .
+  - dj -d Dockerfile.base.jinja -o Dockerfile -e USE_TXC_DXTN=${USE_TXC_DXTN:-no} -e MAKEFLAGS=$MAKEFLAGS
+  - docker build -t igalia/mesa:base .
   # - dj -d Dockerfile.llvm.jinja -o Dockerfile -e LLVM=3.3 -e MAKEFLAGS=$MAKEFLAGS
   # - docker build -f Dockerfile -t igalia/mesa:llvm-3.3 .
   - dj -d Dockerfile.llvm.jinja -o Dockerfile -e LLVM=3.6 -e MAKEFLAGS=$MAKEFLAGS

--- a/Dockerfile.base.jinja
+++ b/Dockerfile.base.jinja
@@ -1,7 +1,13 @@
 #
 # Base image for building Mesa.
 #
-#  `docker build -f Dockerfile.base -t igalia/mesa:base .`
+# ~~~
+#  dj -d Dockerfile.base.jinja -o Dockerfile            \
+#    [-e USE_TXC_DXTN=yes]     # yes, no (default: no)  \
+#    [-e MAKEFLAGS=-j2]        # -j2, j4, ....
+#  docker build -t igalia/mesa:base .
+#  rm Dockerfile
+# ~~~
 #
 
 FROM ubuntu:xenial
@@ -26,12 +32,15 @@ USER local
 
 WORKDIR /home/local
 
+{% if MAKEFLAGS %}
+ENV MAKEFLAGS={{ MAKEFLAGS }}
+{% endif %}
+
 RUN wget http://xorg.freedesktop.org/releases/individual/proto/glproto-1.4.14.tar.bz2   \
   && tar -jxvf glproto-1.4.14.tar.bz2                                                   \
   && rm glproto-1.4.14.tar.bz2                                                          \
   && cd glproto-1.4.14                                                                  \
   && ./configure                                                                        \
-  && export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"                                  \
   && make                                                                               \
   && sudo make install                                                                  \
   && sudo rm -fr ../glproto-1.4.14
@@ -41,7 +50,6 @@ RUN wget http://xorg.freedesktop.org/releases/individual/proto/dri2proto-2.8.tar
   && rm dri2proto-2.8.tar.bz2                                                           \
   && cd dri2proto-2.8                                                                   \
   && ./configure                                                                        \
-  && export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"                                  \
   && make                                                                               \
   && sudo make install                                                                  \
   && sudo rm -fr ../dri2proto-2.8
@@ -51,7 +59,6 @@ RUN wget http://xorg.freedesktop.org/releases/individual/proto/dri3proto-1.0.tar
   && rm dri3proto-1.0.tar.bz2                                                           \
   && cd dri3proto-1.0                                                                   \
   && ./configure                                                                        \
-  && export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"                                  \
   && make                                                                               \
   && sudo make install                                                                  \
   && sudo rm -fr ../dri3proto-1.0
@@ -61,7 +68,6 @@ RUN wget http://xorg.freedesktop.org/releases/individual/proto/presentproto-1.0.
   && rm presentproto-1.0.tar.bz2                                                        \
   && cd presentproto-1.0                                                                \
   && ./configure                                                                        \
-  && export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"                                  \
   && make                                                                               \
   && sudo make install                                                                  \
   && sudo rm -fr ../presentproto-1.0
@@ -71,7 +77,6 @@ RUN wget http://xorg.freedesktop.org/releases/individual/proto/presentproto-1.0.
 #   && rm xcb-proto-1.11.tar.bz2                                  \
 #   && cd xcb-proto-1.11                                          \
 #   && ./configure                                                \
-#   && export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"          \
 #   && make                                                       \
 #   && sudo make install                                          \
 #   && sudo rm -fr ../xcb-proto-1.11
@@ -81,7 +86,6 @@ RUN wget http://xorg.freedesktop.org/releases/individual/proto/presentproto-1.0.
 #   && rm libxcb-1.11.tar.bz2                                     \
 #   && cd libxcb-1.11                                             \
 #   && ./configure                                                \
-#   && export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"          \
 #   && make                                                       \
 #   && sudo make install                                          \
 #   && sudo rm -fr ../libxcb-1.11
@@ -91,27 +95,26 @@ RUN wget http://xorg.freedesktop.org/releases/individual/lib/libxshmfence-1.1.ta
   && rm libxshmfence-1.1.tar.bz2                                                        \
   && cd libxshmfence-1.1                                                                \
   && ./configure                                                                        \
-  && export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"                                  \
   && make                                                                               \
   && sudo make install                                                                  \
   && sudo rm -fr ../libxshmfence-1.1
 
+{% if USE_TXC_DXTN == "yes" %}
 RUN wget https://people.freedesktop.org/~cbrill/libtxc_dxtn/libtxc_dxtn-1.0.1.tar.bz2   \
   && tar -jxvf libtxc_dxtn-1.0.1.tar.bz2                                                \
   && rm libtxc_dxtn-1.0.1.tar.bz2                                                       \
   && cd libtxc_dxtn-1.0.1                                                               \
   && ./configure                                                                        \
-  && export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"                                  \
   && make                                                                               \
   && sudo make install                                                                  \
   && sudo rm -fr ../libtxc_dxtn-1.0.1
+{% endif%}
 
 RUN wget https://wayland.freedesktop.org/releases/wayland-1.13.0.tar.xz                 \
   && tar -Jxvf wayland-1.13.0.tar.xz                                                    \
   && rm wayland-1.13.0.tar.xz                                                           \
   && cd wayland-1.13.0                                                                  \
   && ./configure --disable-documentation                                                \
-  && export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"                                  \
   && make                                                                               \
   && sudo make install                                                                  \
   && sudo rm -fr ../wayland-1.13.0


### PR DESCRIPTION
ibtxc-dxtn uses the patented S3 Texture Compression algorithm.
Therefore, we don't want to use this library but it is still possible
through setting the USE_TXC_DXTN variable in the base image.

According to Wikipedia, the patent expires on October 2, 2017:
https://en.wikipedia.org/wiki/S3_Texture_Compression#Patent

This fixes issue #8.