### PR TITLE
mesa: use ccache to speed up Mesa building

### DIFF
--- a/Dockerfile.base.jinja
+++ b/Dockerfile.base.jinja
@@ -18,7 +18,7 @@ RUN apt-get update                                                              
   && apt-get --no-install-recommends -y install autoconf gcc g++ sudo cmake patch      \
     automake pkg-config libtool-bin bison flex python-pip libpthread-stubs0-dev        \
     wget libxau-dev libx11-dev libxext-dev libxdamage-dev libx11-xcb-dev gettext       \
-    zlib1g-dev scons libelf-dev libxvmc-dev libvdpau-dev libva-dev libclc-dev          \
+    zlib1g-dev scons libelf-dev libxvmc-dev libvdpau-dev libva-dev libclc-dev ccache   \
     libpciaccess-dev libxxf86vm-dev python-setuptools python-wheel bzip2 make          \
     mesa-common-dev libxcb-dri3-dev libxcb-present-dev libxcb-glx0-dev xutils-dev      \
     libxcb-dri2-0-dev libexpat1-dev xz-utils libedit-dev libffi-dev libxml2-dev        \

--- a/Dockerfile.mesa.jinja
+++ b/Dockerfile.mesa.jinja
@@ -62,30 +62,14 @@ ENV PATH=//usr/local/lib/llvm-3.3/bin:$PATH
 ENV PATH=/usr/lib/llvm-{{ LLVM }}/bin:$PATH
 {% endif %}
 
+ENV PATH=/usr/lib/ccache:$PATH
+
 {% if BUILD == "scons" %}
-RUN scons llvm=1                  \
-  && scons llvm=1 check           \
-  && sudo rm -fr /home/local/mesa
+CMD [ "/bin/sh", "-c", "scons llvm=1 && scons llvm=1 check && sudo rm -fr /home/local/mesa" ]
 {% elif BUILD == "windows" %}
-RUN scons platform=windows toolchain=crossmingw \
-  && sudo rm -fr /home/local/mesa
+CMD [ "/bin/sh", "-c", "scons platform=windows toolchain=crossmingw && sudo rm -fr /home/local/mesa" ]
 {% elif BUILD == "distcheck" %}
-RUN ./autogen.sh                  \
-  && make distcheck               \
-  && sudo rm -fr /home/local/mesa
+CMD [ "/bin/sh", "-c", "./autogen.sh && make distcheck && sudo rm -fr /home/local/mesa" ]
 {% else %}
-RUN ./autogen.sh --with-egl-platforms=x11,drm,wayland                           \
-  --with-dri-drivers=i915,i965,radeon,r200,swrast,nouveau                       \
-  --with-gallium-drivers=i915,nouveau,r300{% if LLVM|float >= 3.8 %},r600,radeonsi{% endif %},freedreno,svga,swrast{% if LLVM|float >= 3.9 %},swr{% endif %},vc4,virgl{% if "13.0" not in RELEASE %},etnaviv,imx{% endif %}    \
-  --with-vulkan-drivers=intel{% if LLVM|float >= 3.9 %},radeon{% endif %}       \
-  --enable-llvm --enable-llvm-shared-libs                                       \
-  --enable-glx-tls --enable-gbm --enable-egl                                    \
-  && make                                                                       \
-  && make check                                                                 \
-  && sudo make install                                                          \
-  && sudo rm -fr /home/local/mesa
+CMD [ "/bin/sh", "-c", "./autogen.sh --with-egl-platforms=x11,drm,wayland --with-dri-drivers=i915,i965,radeon,r200,swrast,nouveau --with-gallium-drivers=i915,nouveau,r300{% if LLVM|float >= 3.8 %},r600,radeonsi{% endif %},freedreno,svga,swrast{% if LLVM|float >= 3.9 %},swr{% endif %},vc4,virgl{% if "13.0" not in RELEASE %},etnaviv,imx{% endif %} --with-vulkan-drivers=intel{% if LLVM|float >= 3.9 %},radeon{% endif %} --enable-llvm --enable-llvm-shared-libs --enable-glx-tls --enable-gbm --enable-egl && make && make check && sudo make install && sudo rm -fr /home/local/mesa" ]
 {% endif %}
-
-WORKDIR /home/local
-
-USER root


### PR DESCRIPTION
Split up Mesa image building in two steps: one for preparing it to
compile (docker build) and another one to build mesa (docker run).

This is required because we want to share an external .ccache directory,
but this can't be done in the build, but in the run.

Later we will use docker commit to tag the final image.

This fixes #issue 5.