### PR TITLE
travis: do not hardcode docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,21 +12,21 @@ before_script:
 
 script:
   - dj -d Dockerfile.base.jinja -o Dockerfile -e USE_TXC_DXTN=${USE_TXC_DXTN:-no} -e MAKEFLAGS=$MAKEFLAGS
-  - docker build -t igalia/mesa:base .
+  - docker build -t ${DOCKER_IMAGE:-mesa}:base .
   # - dj -d Dockerfile.llvm.jinja -o Dockerfile -e LLVM=3.3 -e MAKEFLAGS=$MAKEFLAGS
-  # - docker build -f Dockerfile -t igalia/mesa:llvm-3.3 .
+  # - docker build -f Dockerfile -t ${DOCKER_IMAGE:-mesa}:llvm-3.3 .
   - dj -d Dockerfile.llvm.jinja -o Dockerfile -e LLVM=3.6 -e MAKEFLAGS=$MAKEFLAGS
-  - docker build -f Dockerfile -t igalia/mesa:llvm-3.6 .
+  - docker build -f Dockerfile -t ${DOCKER_IMAGE:-mesa}:llvm-3.6 .
   - dj -d Dockerfile.llvm.jinja -o Dockerfile -e LLVM=3.8 -e MAKEFLAGS=$MAKEFLAGS
-  - docker build -f Dockerfile -t igalia/mesa:llvm-3.8 .
+  - docker build -f Dockerfile -t ${DOCKER_IMAGE:-mesa}:llvm-3.8 .
   - dj -d Dockerfile.llvm.jinja -o Dockerfile -e LLVM=3.9 -e MAKEFLAGS=$MAKEFLAGS
-  - docker build -f Dockerfile -t igalia/mesa:llvm-3.9 .
+  - docker build -f Dockerfile -t ${DOCKER_IMAGE:-mesa}:llvm-3.9 .
 
 after_success:
   - if [[ -n "$DOCKER_USERNAME" && "$TRAVIS_BRANCH" == "master" ]]; then
       docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
-      docker push igalia/mesa:base;
-      docker push igalia/mesa:llvm-3.6;
-      docker push igalia/mesa:llvm-3.8;
-      docker push igalia/mesa:llvm-3.9;
+      docker push ${DOCKER_IMAGE:-mesa}:base;
+      docker push ${DOCKER_IMAGE:-mesa}:llvm-3.6;
+      docker push ${DOCKER_IMAGE:-mesa}:llvm-3.8;
+      docker push ${DOCKER_IMAGE:-mesa}:llvm-3.9;
     fi


### PR DESCRIPTION
Use Travis envvar to define the docker tag image, instead of hardcoding
"igalia/mesa".

This fixes issue #1.