### PR TITLE
Use a packaged LLVM 3.3 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,19 +13,20 @@ before_script:
 script:
   - dj -d Dockerfile.base.jinja -o Dockerfile -e USE_TXC_DXTN=${USE_TXC_DXTN:-no} -e MAKEFLAGS=$MAKEFLAGS
   - docker build -t ${DOCKER_IMAGE:-mesa}:base .
-  # - dj -d Dockerfile.llvm.jinja -o Dockerfile -e LLVM=3.3 -e MAKEFLAGS=$MAKEFLAGS
-  # - docker build -f Dockerfile -t ${DOCKER_IMAGE:-mesa}:llvm-3.3 .
-  - dj -d Dockerfile.llvm.jinja -o Dockerfile -e LLVM=3.6 -e MAKEFLAGS=$MAKEFLAGS
+  - dj -d Dockerfile.llvm.jinja -o Dockerfile -e LLVM=3.3
+  - docker build -f Dockerfile -t ${DOCKER_IMAGE:-mesa}:llvm-3.3 .
+  - dj -d Dockerfile.llvm.jinja -o Dockerfile -e LLVM=3.6
   - docker build -f Dockerfile -t ${DOCKER_IMAGE:-mesa}:llvm-3.6 .
-  - dj -d Dockerfile.llvm.jinja -o Dockerfile -e LLVM=3.8 -e MAKEFLAGS=$MAKEFLAGS
+  - dj -d Dockerfile.llvm.jinja -o Dockerfile -e LLVM=3.8
   - docker build -f Dockerfile -t ${DOCKER_IMAGE:-mesa}:llvm-3.8 .
-  - dj -d Dockerfile.llvm.jinja -o Dockerfile -e LLVM=3.9 -e MAKEFLAGS=$MAKEFLAGS
+  - dj -d Dockerfile.llvm.jinja -o Dockerfile -e LLVM=3.9
   - docker build -f Dockerfile -t ${DOCKER_IMAGE:-mesa}:llvm-3.9 .
 
 after_success:
   - if [[ -n "$DOCKER_USERNAME" && "$TRAVIS_BRANCH" == "master" ]]; then
       docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
       docker push ${DOCKER_IMAGE:-mesa}:base;
+      docker push ${DOCKER_IMAGE:-mesa}:llvm-3.3;
       docker push ${DOCKER_IMAGE:-mesa}:llvm-3.6;
       docker push ${DOCKER_IMAGE:-mesa}:llvm-3.8;
       docker push ${DOCKER_IMAGE:-mesa}:llvm-3.9;

--- a/Dockerfile.llvm.jinja
+++ b/Dockerfile.llvm.jinja
@@ -4,10 +4,23 @@
 # ~~~
 #  dj -d Dockerfile.llvm.jinja -o Dockerfile       \
 #    -e LLVM=3.3            # 3.3, 3.6, 3.8 or 3.9 \
-#    [-e MAKEFLAGS=-j2]     # -j2, -j4 ...
 #  docker build --pull -f Dockerfile -t igalia/mesa:{{ LLVM }} .
 #  rm Dockerfile
 # ~~~
+#
+# LLVM 3.3 package has been created with checkinstall using Base image
+#
+# ~~~
+#  wget http://releases.llvm.org/3.3/llvm-3.3.src.tar.gz                                \
+#    && tar xzpf llvm-3.3.src.tar.gz                                                    \
+#    && cd llvm-3.3.src                                                                 \
+#    && mkdir build                                                                     \
+#    && cd build                                                                        \
+#    && ../configure --enable-optimized --enable-shared --prefix=/usr/lib/llvm-3.3      \
+#    && make                                                                            \
+#    && echo "LLVM Toolchain 3.3" > description-pak                                     \
+#    && checkinstall -D -y --pkgname=llvm-3.3 --pkgversion=3.3 --pkgrelease=+checkinstall1 --maintainer=jasuarez@igalia.com --provides=llvm
+#  ~~~
 #
 
 FROM igalia/mesa:base
@@ -30,27 +43,8 @@ RUN apt-get update                                                            \
 RUN apt-get update                                                            \
   && apt-get --no-install-recommends -y install libclang-3.6-dev llvm-3.6-dev \
   && rm -fr /var/lib/apt/lists/*
+{% elif LLVM == "3.3" %}
+RUN wget https://people.igalia.com/jasuarez/packages/llvm-3.3_3.3-+checkinstall1_amd64.deb      \
+  && dpkg -i llvm-3.3_3.3-+checkinstall1_amd64.deb                                              \
+  && rm llvm-3.3_3.3-+checkinstall1_amd64.deb
 {% endif %}
-
-{% if MAKEFLAGS %}
-ENV MAKEFLAGS={{ MAKEFLAGS }}
-{% endif %}
-
-USER local
-
-WORKDIR /home/local
-
-{% if LLVM == "3.3" %}
-RUN wget http://releases.llvm.org/3.3/llvm-3.3.src.tar.gz                             \
-  && tar xzpf llvm-3.3.src.tar.gz                                                     \
-  && rm llvm-3.3.src.tar.gz                                                           \
-  && cd llvm-3.3.src                                                                  \
-  && mkdir build                                                                      \
-  && cd build                                                                         \
-  && ../configure --enable-optimized --enable-shared --prefix=/usr/local/lib/llvm-3.3 \
-  && make                                                                             \
-  && sudo make install                                                                \
-  && sudo rm -fr ../../llvm-3.3.src
-{% endif %}
-
-USER root

--- a/Dockerfile.mesa.jinja
+++ b/Dockerfile.mesa.jinja
@@ -56,13 +56,7 @@ WORKDIR /home/local/mesa
 
 RUN git show --stat > /home/local/mesa-head.txt
 
-{% if LLVM == "3.3" %}
-ENV PATH=//usr/local/lib/llvm-3.3/bin:$PATH
-{% else %}
-ENV PATH=/usr/lib/llvm-{{ LLVM }}/bin:$PATH
-{% endif %}
-
-ENV PATH=/usr/lib/ccache:$PATH
+ENV PATH=/usr/lib/ccache:/usr/lib/llvm-{{ LLVM }}/bin:$PATH
 
 {% if BUILD == "scons" %}
 CMD [ "/bin/sh", "-c", "scons llvm=1 && scons llvm=1 check && sudo rm -fr /home/local/mesa" ]


### PR DESCRIPTION
Unfortunately, LLVM 3.3 is not packaged for Ubuntu Xenial. And
porting from old Ubuntu Trusty is causing lot of troubles.

So we were just building LLVM 3.3 from scratch. But this takes time.
Fortunately, we can package that manually-built version directly using
checkinstall.

This commit just uses LLVM 3.3 from a package created with checkinstall.
It contains the same version as if it were build manually.

This fixes issue #15.