### PR TITLE
rocker: add DEBUG variable to mesa file

### DIFF
--- a/Rockerfile.mesa
+++ b/Rockerfile.mesa
@@ -4,6 +4,7 @@
 # ~~~
 #  rocker build -f Rockerfile.mesa [--attach]                                            \
 #    --var BUILD=autotools      # scons, autotools, windows, distcheck, gallium, android \
+#    [--var DEBUG=true]         # true, false                                            \
 #    [--var LLVM=3.3]           # 3.3, 3.6, 3.8, 3.9 or 4.0                              \
 #    [--var TAG=master]         # master, pre-release-17.0, pre-release-13.0, ...        \
 #    [--var RELEASE=master]     # master, pre-release/17.0, pre-release/13.0, ...
@@ -18,6 +19,7 @@
 {{ $image := (or .Env.DOCKER_IMAGE "igalia/mesa") }}
 {{ $ccachedir := (or .Env.CCACHE_DIR "~/.ccache") }}
 {{ $llvm_version := (or .LLVM "0.0") }}
+{{ $debug_build := (or .DEBUG "false") }}
 
 {{ if eq .BUILD "windows" }}
 FROM {{ $image }}:base
@@ -150,6 +152,7 @@ RUN export LLVM={{ $llvm_version }}.0\
   && ./autogen.sh --with-dri-drivers=""                             \
     --with-gallium-drivers=$GALLIUM_DRIVERS                         \
     {{ if ne $llvm_version "0.0" }} --enable-llvm --enable-llvm-shared-libs {{ end }}   \
+    {{ if eq $debug_build "true" }} --enable-debug {{ end }}              \
     --disable-glx --disable-gbm --disable-egl                       \
   && make                                                           \
   && make check                                                     \
@@ -168,6 +171,7 @@ RUN export LLVM={{ $llvm_version }}.0\
     --with-gallium-drivers=$GALLIUM_DRIVERS                         \
     --with-vulkan-drivers=$VULKAN_DRIVERS                           \
     {{ if ne $llvm_version "0.0" }} --enable-llvm --enable-llvm-shared-libs {{ end }}   \
+    {{ if eq $debug_build "true" }} --enable-debug {{ end }}              \
     --enable-glx-tls --enable-gbm --enable-egl                      \
   && make                                                           \
   && make check                                                     \

--- a/crontab-daily-local-piglit.sh
+++ b/crontab-daily-local-piglit.sh
@@ -211,9 +211,7 @@ function build_mesa() {
     wget https://raw.githubusercontent.com/Igalia/mesa-dockerfiles/master/Rockerfile.mesa
     # make check is failing right now and we don't really need it
     sed -e 's/&& make check//g' -i Rockerfile.mesa
-    # compiling without debug will trigger dangerous segfauls. We will rather assert
-    sed -e 's/\(--with-vulkan-drivers\)/--enable-debug \1/g' -i Rockerfile.mesa
-    rocker build -f Rockerfile.mesa --var BUILD="autotools" --var LLVM="3.9" --var TAG=released-17.1.2."$CFPR_MESA_COMMIT"
+    rocker build -f Rockerfile.mesa --var BUILD="autotools" --var LLVM="3.9" --var DEBUG=true --var TAG=released-17.1.2."$CFPR_MESA_COMMIT"
     popd
 
     return 0

--- a/crontab-daily-piglit.sh
+++ b/crontab-daily-piglit.sh
@@ -259,7 +259,7 @@ function run_piglit_tests {
 
 
     if $CDP_RUN_PIGLIT; then
-	rocker build --pull -f Rockerfile.piglit --var TAG=piglit --var RELEASE="${CDP_RELEASE}"
+	rocker build --pull -f Rockerfile.piglit --var DEBUG=true --var TAG=piglit --var RELEASE="${CDP_RELEASE}"
 	CDP_TEST_SUITES="piglit $CDP_TEST_SUITES"
     fi
 
@@ -272,7 +272,7 @@ function run_piglit_tests {
 	git pull
 	cd -
 	cd $HOME
-	rocker build --pull -f Rockerfile.vk-gl-cts --var VIDEO_GID=`getent group video | cut -f3 -d:` --var TAG=vk-gl-cts --var RELEASE="${CDP_RELEASE}"
+	rocker build --pull -f Rockerfile.vk-gl-cts --var VIDEO_GID=`getent group video | cut -f3 -d:` --var DEBUG=true --var TAG=vk-gl-cts --var RELEASE="${CDP_RELEASE}"
 	rm Rockerfile.vk-gl-cts
 	cd -
     fi


### PR DESCRIPTION
With the DEBUG variable we instruct the mesa image to be build using
the "--enable-debug" flag.

Additinally, the cron scripts have been also updated to use those
images with the mesa build with "--enable-debug".